### PR TITLE
Update falsehoods about emails.

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ The consequence of wrong calendar accounting.
 
 - [I Knew How to Validate an Email Address Until I Read the
 RFC](https://haacked.com/archive/2007/08/21/i-knew-how-to-validate-an-email-address-until-i.aspx/) -
-Provides intricate examples that are unsuspected valid emails according the
+Provides intricate examples that are unsuspected valid email addresses according the
 RFC-822.
 
 


### PR DESCRIPTION
An update to the description text for the existing link. The article is specifically about email addresses, not emails themselves.