### PR TITLE
Added article that discusses the problems with parsing addresses using regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,9 @@ Covers streets, postal codes, buildings, cities and countries.
 - [Letter Delivered Despite No Name, No
 Address](https://twitter.com/loriskumo/status/735851511331356672) - Ultimate
 falsehood about postal addresses: you do not need one.
-- [Regex and Postal Addresses](https://smartystreets.com/articles/regular-expressions-for-street-addresses) - Why regular expressions and street addresses do not mix.
+- [Regex and Postal
+Addresses](https://smartystreets.com/articles/regular-expressions-for-street-addresses) -
+Why regular expressions and street addresses do not mix.
 - [`libaddressinput`](https://github.com/googlei18n/libaddressinput) - Google's
 common C++ and Java library for parsing, formatting, and validating
 international postal addresses.

--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ Covers streets, postal codes, buildings, cities and countries.
 - [Letter Delivered Despite No Name, No
 Address](https://twitter.com/loriskumo/status/735851511331356672) - Ultimate
 falsehood about postal addresses: you do not need one.
+- [Regex and Postal Addresses](https://smartystreets.com/articles/regular-expressions-for-street-addresses) - Why regular expressions and street addresses do not mix.
 - [`libaddressinput`](https://github.com/googlei18n/libaddressinput) - Google's
 common C++ and Java library for parsing, formatting, and validating
 international postal addresses.


### PR DESCRIPTION
I have found that there is a [huge misconception](https://stackoverflow.com/search?q=%5Bregex%5D+street+address) that postal addresses follow a pattern enough to use regex to parse them. This article provides basic information on the dangers of doing so. 

I discovered your repo a few weeks ago and instantly thought of this article when I saw there was a section for Postal Addresses.