### PR TITLE
Replace "Falsehoods About Falsehoods Lists" URL with archive.org snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ the world of falsehoods.
 Programming](https://chiselapp.com/user/ttmrichter/repository/gng/doc/trunk/output/falsehoods.html) -
 A humbling and fun list on programming and programmers themselves.
 - [Falsehoods About Falsehoods
-Lists](https://kevin.deldycke.com/2016/12/falsehoods-programmers-believe-about-falsehoods-lists/) -
+Lists](https://web.archive.org/web/20170221055629/https://kevin.deldycke.com/2016/12/falsehoods-programmers-believe-about-falsehoods-lists/) -
 Meta commentary on how these falsehoods shouldn't be handled.
 
 


### PR DESCRIPTION
The provided URL https://kevin.deldycke.com/2016/12/falsehoods-programmers-believe-about-falsehoods-lists/ is replying with an HTTPS certificate that is more than 240 days old. To allow people to see this URL without having to ignore browser certificate warnings, this commit replaces the bad URL with an archived version.