### PR TITLE
Add a list of mistaken perspectives on Bitcoin

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -199,6 +199,7 @@ On character encoding, string formatting, unicode and internationalization.
 - [Myths about CPU Caches](https://software.rajivprab.com/2018/04/29/myths-programmers-believe-about-cpu-caches/) - Misconceptions about caches often lead to false assertions, especially when it comes to concurrency and race conditions.
 - [The Hidden Complexity of Downloading Favicons, Told in 15+ Edge Cases](https://www.simplecto.com/complexity-downloading-favicons-told-in-15-plus-edge-cases/) - Downloading that little icon you see in you browser tabs should be a simple exercise. It turned out to be a lot more complicated than you think. Be vigilant that you are not shaving a Yak.
 - [Norway is not False](https://mobile.twitter.com/chrisjrn/status/1232016100038266880) - Norway's ISO country code is also valid YAML for False.
+- [Falsehoods About Bitcoin](https://github.com/theborakompanioni/spring-boot-bitcoin-starter/blob/master/docs/FALSEHOODS.md) - A list of mistaken perspectives on Bitcoin.
 
 ## Typography
 


### PR DESCRIPTION
#### Preliminary checks

* [x] I have [read the Code of Conduct](https://github.com/kdeldycke/awesome-falsehood/blob/main/.github/code-of-conduct.md)
* [x] I applied all rules from the [Contributing guide](https://github.com/kdeldycke/awesome-falsehood/blob/main/.github/contributing.md)
* [x] I have checked there is not other [Issues](https://github.com/kdeldycke/awesome-falsehood/issues) or [Pull Requests](https://github.com/kdeldycke/awesome-falsehood/pulls) covering the same topic to open

#### Summary
There has been no "Falsehood Programmers Believe.." list about Bitcoin. Now there is. It's not much, but it's a start.