### PR TITLE
Fix link to meta falsehoods

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -60,7 +60,7 @@ The *falsehood* articles listed below will have a comprehensive list of those fa
 
 - [Falsehoods Programmers Believe](https://spaceninja.com/2015/12/07/falsehoods-programmers-believe/) - A brief list of common falsehoods. A great overview and quick introduction into the world of falsehoods.
 - [Falsehoods about Programming](https://chiselapp.com/user/ttmrichter/repository/gng/doc/trunk/output/falsehoods.html) - A humbling and fun list on programming and programmers themselves.
-- [Falsehoods about Falsehoods Lists](https://kevin.deldycke.com/2016/12/falsehoods-programmers-believe-about-falsehoods-lists/) - Meta commentary on how these falsehoods shouldn't be handled.
+- [Falsehoods about Falsehoods Lists](https://kevin.deldycke.com/2016/falsehoods-programmers-believe-about-falsehoods-lists) - Meta commentary on how these falsehoods shouldn't be handled.
 
 ## Arts
 


### PR DESCRIPTION
### Motivation

https://github.com/kdeldycke/awesome-falsehood/issues/162

### Affiliation

<!-- Please indicate how you are associated with the new proposed content: -->

- [ ] I am the author of the article or project
- [ ] I am working for/with the company which is publishing the article or project
- [x] I'm just a rando who stumbled upon this via social networks

### Self checks

- [x] I have [read the Code of Conduct](https://github.com/kdeldycke/awesome-falsehood/blob/main/.github/code-of-conduct.md)
- [x] I applied all rules from the [Contributing guide](https://github.com/kdeldycke/awesome-falsehood/blob/main/.github/contributing.md)
- [x] I have checked there is no other [Issues](https://github.com/kdeldycke/awesome-falsehood/issues) or [Pull Requests](https://github.com/kdeldycke/awesome-falsehood/pulls) covering the same topic to open
